### PR TITLE
Update to v6 of AppsFlyerFramework

### DIFF
--- a/Rudder-Appsflyer.podspec
+++ b/Rudder-Appsflyer.podspec
@@ -20,5 +20,5 @@ Rudder is a platform for collecting, storing and routing customer event data to 
   s.source_files = 'Rudder-Appsflyer/Classes/**/*'
 
   s.dependency 'Rudder'
-  s.dependency 'Beta-AppsFlyerFramework'
+  s.dependency 'AppsFlyerFramework'
 end


### PR DESCRIPTION
Updates Podspec to use AppsFlyerFramework. v6 of the framework is no longer beta