### PR TITLE
Implemented Screen call changes

### DIFF
--- a/Rudder-Appsflyer.podspec
+++ b/Rudder-Appsflyer.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'Rudder-Appsflyer'
-  s.version          = '1.0.3'
+  s.version          = '1.0.4'
   s.summary          = 'Privacy and Security focused Segment-alternative. Appsflyer Native SDK integration support.'
 
   s.description      = <<-DESC
@@ -10,7 +10,7 @@ Rudder is a platform for collecting, storing and routing customer event data to 
   s.homepage         = 'https://github.com/rudderlabs/rudder-integration-appsflyer-ios'
   s.license          = { :type => "Apache", :file => "LICENSE" }
   s.author           = { 'RudderStack' => 'arnab@rudderlabs.com' }
-  s.source           = { :git => 'https://github.com/rudderlabs/rudder-integration-appsflyer-ios.git', :tag => 'v1.0.3'}
+  s.source           = { :git => 'https://github.com/rudderlabs/rudder-integration-appsflyer-ios.git', :tag => 'v1.0.4'}
   s.platform         = :ios, "9.0"
 
   s.ios.deployment_target = '10.0'
@@ -25,6 +25,6 @@ Rudder is a platform for collecting, storing and routing customer event data to 
 
   s.source_files = 'Rudder-Appsflyer/Classes/**/*'
 
-  s.dependency 'Rudder'
-  s.dependency 'AppsFlyerFramework'
+  s.dependency 'Rudder', '1.2.1'
+  s.dependency 'AppsFlyerFramework', '6.4.3'
 end

--- a/Rudder-Appsflyer.podspec
+++ b/Rudder-Appsflyer.podspec
@@ -25,6 +25,6 @@ Rudder is a platform for collecting, storing and routing customer event data to 
 
   s.source_files = 'Rudder-Appsflyer/Classes/**/*'
 
-  s.dependency 'Rudder', '1.2.1'
-  s.dependency 'AppsFlyerFramework', '6.4.3'
+  s.dependency 'Rudder', '~> 1.2.1'
+  s.dependency 'AppsFlyerFramework', '~> 6.4.3'
 end

--- a/Rudder-Appsflyer.podspec
+++ b/Rudder-Appsflyer.podspec
@@ -25,6 +25,6 @@ Rudder is a platform for collecting, storing and routing customer event data to 
 
   s.source_files = 'Rudder-Appsflyer/Classes/**/*'
 
-  s.dependency 'Rudder', '~> 1.2.1'
-  s.dependency 'AppsFlyerFramework', '~> 6.4.3'
+  s.dependency 'Rudder', '~> 1.0'
+  s.dependency 'AppsFlyerFramework', '6.4.3'
 end

--- a/Rudder-Appsflyer/Classes/RudderAppsflyerIntegration.h
+++ b/Rudder-Appsflyer/Classes/RudderAppsflyerIntegration.h
@@ -11,10 +11,11 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface RudderAppsflyerIntegration : NSObject<RSIntegration>
+@interface RudderAppsflyerIntegration : NSObject<RSIntegration> {
+    BOOL isNewScreenEnabled;
+    AppsFlyerLib *afLib;
+}
 
-@property (nonatomic, strong) AppsFlyerLib *afLib;
-@property (nonatomic) BOOL isNewScreenEnabled;
 
 - (instancetype)initWithConfig:(NSDictionary *)config withAnalytics:(RSClient *)client withRudderConfig:(RSConfig*) rudderConfig;
 

--- a/Rudder-Appsflyer/Classes/RudderAppsflyerIntegration.h
+++ b/Rudder-Appsflyer/Classes/RudderAppsflyerIntegration.h
@@ -7,13 +7,11 @@
 
 #import <Foundation/Foundation.h>
 #import <Rudder/Rudder.h>
-#import <AppsFlyerLib/AppsFlyerLib.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @interface RudderAppsflyerIntegration : NSObject<RSIntegration> {
     BOOL isNewScreenEnabled;
-    AppsFlyerLib *afLib;
 }
 
 

--- a/Rudder-Appsflyer/Classes/RudderAppsflyerIntegration.h
+++ b/Rudder-Appsflyer/Classes/RudderAppsflyerIntegration.h
@@ -14,6 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RudderAppsflyerIntegration : NSObject<RSIntegration>
 
 @property (nonatomic, strong) AppsFlyerLib *afLib;
+@property (nonatomic) BOOL includeScreen;
 
 - (instancetype)initWithConfig:(NSDictionary *)config withAnalytics:(RSClient *)client withRudderConfig:(RSConfig*) rudderConfig;
 

--- a/Rudder-Appsflyer/Classes/RudderAppsflyerIntegration.h
+++ b/Rudder-Appsflyer/Classes/RudderAppsflyerIntegration.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface RudderAppsflyerIntegration : NSObject<RSIntegration>
 
 @property (nonatomic, strong) AppsFlyerLib *afLib;
-@property (nonatomic) BOOL includeScreen;
+@property (nonatomic) BOOL isNewScreenEnabled;
 
 - (instancetype)initWithConfig:(NSDictionary *)config withAnalytics:(RSClient *)client withRudderConfig:(RSConfig*) rudderConfig;
 

--- a/Rudder-Appsflyer/Classes/RudderAppsflyerIntegration.m
+++ b/Rudder-Appsflyer/Classes/RudderAppsflyerIntegration.m
@@ -6,6 +6,7 @@
 //
 
 #import "RudderAppsflyerIntegration.h"
+#import <AppsFlyerLib/AppsFlyerLib.h>
 
 @implementation RudderAppsflyerIntegration
 
@@ -19,19 +20,17 @@
         isNewScreenEnabled = [[config objectForKey:@"useRichEventName"] boolValue];
         
         if (devKey != nil) {
-            afLib = [AppsFlyerLib shared];
-            
-            [afLib setAppsFlyerDevKey:devKey];
-            [afLib setAppleAppID:appleAppId];
+            [[AppsFlyerLib shared] setAppsFlyerDevKey:devKey];
+            [[AppsFlyerLib shared] setAppleAppID:appleAppId];
             
             if (rudderConfig.logLevel >= RSLogLevelDebug) {
-                afLib.isDebug = YES;
+                [AppsFlyerLib shared].isDebug = YES;
             } else {
-                afLib.isDebug = NO;
+                [AppsFlyerLib shared].isDebug = NO;
             }
         }
         
-        [afLib start];
+        [[AppsFlyerLib shared] start];
     }
     [RSLogger logDebug:@"Initializing Appsflyer SDK"];
     return self;
@@ -47,14 +46,14 @@
     NSString *type = message.type;
     if ([type isEqualToString:@"identify"]) {
         if ([NSThread isMainThread]) {
-            [afLib setCustomerUserID:message.userId];
+            [[AppsFlyerLib shared] setCustomerUserID:message.userId];
         } else {
             dispatch_async(dispatch_get_main_queue(), ^{
-                [self->afLib setCustomerUserID:message.userId];
+                [[AppsFlyerLib shared] setCustomerUserID:message.userId];
             });
         }
         if ([message.context.traits[@"currencyCode"] isKindOfClass:[NSString class]]) {
-            afLib.currencyCode = [[NSString alloc] initWithFormat:@"%@", message.context.traits[@"currencyCode"]];
+            [AppsFlyerLib shared].currencyCode = [[NSString alloc] initWithFormat:@"%@", message.context.traits[@"currencyCode"]];
         }
         
         NSMutableDictionary *afTraits = [[NSMutableDictionary alloc] init];
@@ -74,7 +73,7 @@
             [afTraits setObject:message.context.traits[@"username"] forKey:@"username"];
         }
         
-        [afLib setAdditionalData:afTraits];
+        [[AppsFlyerLib shared] setAdditionalData:afTraits];
     } else if ([type isEqualToString:@"track"]) {
         NSString *eventName = message.event;
         if (eventName != nil) {
@@ -118,7 +117,7 @@
                     }
                 }
             }
-            [afLib logEvent:afEventName withValues:afProperties];
+            [[AppsFlyerLib shared] logEvent:afEventName withValues:afProperties];
         }
     } else if ([type isEqualToString:@"screen"]) {
         NSString *screenName;
@@ -136,7 +135,7 @@
         else {
             screenName = @"screen";
         }
-        [afLib logEvent:screenName withValues:properties];
+        [[AppsFlyerLib shared] logEvent:screenName withValues:properties];
     }
 }
 

--- a/Rudder-Appsflyer/Classes/RudderAppsflyerIntegration.m
+++ b/Rudder-Appsflyer/Classes/RudderAppsflyerIntegration.m
@@ -122,13 +122,21 @@
         }
     } else if ([type isEqualToString:@"screen"]) {
         NSString *screenName;
+        NSDictionary *properties = message.properties;
         if (self->isNewScreenEnabled) {
-            screenName = [[NSString alloc] initWithFormat:@"Viewed %@ Screen", message.event];
+            if ([message.event length]) {
+                screenName = [[NSString alloc] initWithFormat:@"Viewed %@ Screen", message.event];
+            } else if (properties != NULL && [[properties objectForKey:@"name"] length]) {
+                screenName = [[NSString alloc] initWithFormat:@"Viewed %@ Screen", [properties objectForKey:@"name"]];
+            }
+            else {
+                screenName = @"Viewed Screen";
+            }
         }
         else {
             screenName = @"screen";
         }
-        [afLib logEvent:screenName withValues:message.properties];
+        [afLib logEvent:screenName withValues:properties];
     }
 }
 

--- a/Rudder-Appsflyer/Classes/RudderAppsflyerIntegration.m
+++ b/Rudder-Appsflyer/Classes/RudderAppsflyerIntegration.m
@@ -16,22 +16,22 @@
     if (self) {
         NSString *devKey = [config objectForKey:@"devKey"];
         NSString *appleAppId = [config objectForKey:@"appleAppId"];
-        _isNewScreenEnabled = [[config objectForKey:@"useRichEventName"] boolValue];
+        isNewScreenEnabled = [[config objectForKey:@"useRichEventName"] boolValue];
         
         if (devKey != nil) {
-            _afLib = [AppsFlyerLib shared];
+            afLib = [AppsFlyerLib shared];
             
-            [_afLib setAppsFlyerDevKey:devKey];
-            [_afLib setAppleAppID:appleAppId];
+            [afLib setAppsFlyerDevKey:devKey];
+            [afLib setAppleAppID:appleAppId];
             
             if (rudderConfig.logLevel >= RSLogLevelDebug) {
-                _afLib.isDebug = YES;
+                afLib.isDebug = YES;
             } else {
-                _afLib.isDebug = NO;
+                afLib.isDebug = NO;
             }
         }
         
-        [_afLib start];
+        [afLib start];
     }
     [RSLogger logDebug:@"Initializing Appsflyer SDK"];
     return self;
@@ -47,14 +47,14 @@
     NSString *type = message.type;
     if ([type isEqualToString:@"identify"]) {
         if ([NSThread isMainThread]) {
-            [_afLib setCustomerUserID:message.userId];
+            [afLib setCustomerUserID:message.userId];
         } else {
             dispatch_async(dispatch_get_main_queue(), ^{
-                [self.afLib setCustomerUserID:message.userId];
+                [self->afLib setCustomerUserID:message.userId];
             });
         }
         if ([message.context.traits[@"currencyCode"] isKindOfClass:[NSString class]]) {
-            _afLib.currencyCode = [[NSString alloc] initWithFormat:@"%@", message.context.traits[@"currencyCode"]];
+            afLib.currencyCode = [[NSString alloc] initWithFormat:@"%@", message.context.traits[@"currencyCode"]];
         }
         
         NSMutableDictionary *afTraits = [[NSMutableDictionary alloc] init];
@@ -74,7 +74,7 @@
             [afTraits setObject:message.context.traits[@"username"] forKey:@"username"];
         }
         
-        [_afLib setAdditionalData:afTraits];
+        [afLib setAdditionalData:afTraits];
     } else if ([type isEqualToString:@"track"]) {
         NSString *eventName = message.event;
         if (eventName != nil) {
@@ -118,17 +118,17 @@
                     }
                 }
             }
-            [_afLib logEvent:afEventName withValues:afProperties];
+            [afLib logEvent:afEventName withValues:afProperties];
         }
     } else if ([type isEqualToString:@"screen"]) {
         NSString *screenName;
-        if (self.isNewScreenEnabled) {
+        if (self->isNewScreenEnabled) {
             screenName = [[NSString alloc] initWithFormat:@"Viewed %@ Screen", message.event];
         }
         else {
             screenName = @"screen";
         }
-        [_afLib logEvent:screenName withValues:message.properties];
+        [afLib logEvent:screenName withValues:message.properties];
     }
 }
 

--- a/Rudder-Appsflyer/Classes/RudderAppsflyerIntegration.m
+++ b/Rudder-Appsflyer/Classes/RudderAppsflyerIntegration.m
@@ -16,7 +16,7 @@
     if (self) {
         NSString *devKey = [config objectForKey:@"devKey"];
         NSString *appleAppId = [config objectForKey:@"appleAppId"];
-        _includeScreen = [config objectForKey:@"includeScreenOrPageName"];
+        _isNewScreenEnabled = [config objectForKey:@"useRichEventName"];
         
         if (devKey != nil) {
             _afLib = [AppsFlyerLib shared];
@@ -122,7 +122,7 @@
         }
     } else if ([type isEqualToString:@"screen"]) {
         NSString *screenName;
-        if (self.includeScreen) {
+        if (self.isNewScreenEnabled) {
             screenName = [[NSString alloc] initWithFormat:@"Viewed %@ Screen", message.event];
         }
         else {

--- a/Rudder-Appsflyer/Classes/RudderAppsflyerIntegration.m
+++ b/Rudder-Appsflyer/Classes/RudderAppsflyerIntegration.m
@@ -16,6 +16,7 @@
     if (self) {
         NSString *devKey = [config objectForKey:@"devKey"];
         NSString *appleAppId = [config objectForKey:@"appleAppId"];
+        _includeScreen = [config objectForKey:@"includeScreenOrPageName"];
         
         if (devKey != nil) {
             _afLib = [AppsFlyerLib shared];
@@ -120,7 +121,14 @@
             [_afLib logEvent:afEventName withValues:afProperties];
         }
     } else if ([type isEqualToString:@"screen"]) {
-        [_afLib logEvent:@"screen" withValues:message.properties];
+        NSString *screenName;
+        if (self.includeScreen) {
+            screenName = [[NSString alloc] initWithFormat:@"Viewed %@ Screen", message.event];
+        }
+        else {
+            screenName = @"screen";
+        }
+        [_afLib logEvent:screenName withValues:message.properties];
     }
 }
 
@@ -226,6 +234,11 @@
 - (void)reset {
     // Appsflyer doesn't support reset functionality
 }
+
+- (void)flush {
+    // Appsflyer doesn't support flush functionality
+}
+
 
 @end
 

--- a/Rudder-Appsflyer/Classes/RudderAppsflyerIntegration.m
+++ b/Rudder-Appsflyer/Classes/RudderAppsflyerIntegration.m
@@ -16,7 +16,7 @@
     if (self) {
         NSString *devKey = [config objectForKey:@"devKey"];
         NSString *appleAppId = [config objectForKey:@"appleAppId"];
-        _isNewScreenEnabled = [config objectForKey:@"useRichEventName"];
+        _isNewScreenEnabled = [[config objectForKey:@"useRichEventName"] boolValue];
         
         if (devKey != nil) {
             _afLib = [AppsFlyerLib shared];


### PR DESCRIPTION
## Description of the change

- If useRichEventName is enabled at the control plane then screen eventName will be sent in new format.
- Else older format.
- Increased the minSdkVersion of the AppsFlyer sample app to 19, as our Android-SDK min version is 19.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
