### PR TITLE
chore(release): pulling release/2.1.0 into master

### DIFF
--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -16,7 +16,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           PROJECT_NAME: 'iOS AppsFlyer SDK'
         with:
-          channel-id: 'CTAGMVC3C'
+          channel-id: "${{ secrets.SLACK_RELEASE_CHANNEL_ID }}"
           payload: |
             {
               "blocks": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+## 2.1.0 (2022-11-17)
+
+
+### Features
+
+* replace space with underscore for customEvents ([1e03ecc](https://github.com/rudderlabs/rudder-integration-appsflyer-ios/commit/1e03eccad6cca29d4eba6fc51f1365d6db3e2266))

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -8,8 +8,8 @@ PODS:
   - FBSnapshotTestCase/SwiftSupport (2.1.4):
     - FBSnapshotTestCase/Core
   - Rudder (1.2.1)
-  - Rudder-Appsflyer (1.0.4):
-    - AppsFlyerFramework (= 6.4.3)
+  - Rudder-Appsflyer (2.0.0):
+    - AppsFlyerFramework (~> 6.4.3)
     - Rudder (~> 1.0)
 
 DEPENDENCIES:
@@ -30,8 +30,8 @@ SPEC CHECKSUMS:
   AppsFlyerFramework: ce218e29f57ea92e461ca1b6f418148a1be2e0dc
   FBSnapshotTestCase: 094f9f314decbabe373b87cc339bea235a63e07a
   Rudder: db8cfa8e5757599dfec74a1bdd04dc17b3859789
-  Rudder-Appsflyer: e070a12a5ff094b922a513b21a0f8a185f948ef9
+  Rudder-Appsflyer: c60efa0d7711d0d09a49a3733f11551ee38800cc
 
 PODFILE CHECKSUM: c83c5f5286f9b840b966f5e22ef98b97471c62d5
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3

--- a/Rudder-Appsflyer/Classes/RudderAppsflyerIntegration.m
+++ b/Rudder-Appsflyer/Classes/RudderAppsflyerIntegration.m
@@ -102,6 +102,9 @@ NSString *const FIRSTPURCHASE = @"first_purchase";
                     }
                 }
             }
+            else {
+                afEventName = [afEventName stringByReplacingOccurrencesOfString:@" " withString:@"_"];
+            }
             [[AppsFlyerLib shared] logEvent:afEventName withValues:afProperties];
         }
     } else if ([type isEqualToString:@"screen"]) {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }


### PR DESCRIPTION
:crown: *An automated PR*

   2.0.0 (2022-11-17)<br> * ci: fix publish-new-release ([94e5075](https://github.com/rudderlabs/rudder-integration-appsflyer-ios/commit/94e5075))<br> * ci: replaced channel-id value with secret ([29755ac](https://github.com/rudderlabs/rudder-integration-appsflyer-ios/commit/29755ac))<br> * feat: replace space with underscore for customEvents ([1e03ecc](https://github.com/rudderlabs/rudder-integration-appsflyer-ios/commit/1e03ecc))