### PR TITLE
chore(release): pulling release/2.5.0 into master

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -86,4 +86,4 @@ jobs:
           github_token: ${{ secrets.PAT }}
           pr_title: "chore(release): pulling ${{ steps.create-release.outputs.branch_name }} into master"
           pr_body: ":crown: *An automated PR*\n\n${{ steps.finish-release.outputs.commit_summary }}"
-          pr_reviewer: 'pallabmaiti'
+          pr_reviewer: 'desusai7'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 2.5.0 (2024-03-06)
+
+
+### Features
+
+* set maximum version of AppsFlyer SDK to less than 7.0.0 in Package.swift ([0e70161](https://github.com/rudderlabs/rudder-integration-appsflyer-ios/commit/0e7016142ae081d0249e26e82595dfe3a306a9f5))
+
 ## 2.4.0 (2023-12-12)
 
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @pallabmaiti @itsdebs
+* @desusai7 @itsdebs

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/AppsFlyerSDK/AppsFlyerFramework",
         "state": {
           "branch": null,
-          "revision": "0d8359239a349db4ac2aba8efe2ad8835fc799b5",
-          "version": "6.12.2"
+          "revision": "4591cd113ea1af6fa950479fadbce2f13bab8895",
+          "version": "6.13.1"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/rudderlabs/crash-reporter-ios",
         "state": {
           "branch": null,
-          "revision": "f8fc2f043332033aa49aed21180f3742bf05b61d",
-          "version": "1.1.0"
+          "revision": "ee563535b64d9d5feacd0fa243663b2658033a19",
+          "version": "1.0.1"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/rudderlabs/metrics-reporter-ios",
         "state": {
           "branch": null,
-          "revision": "fae035db90a966f863f34442051d2be3f3605c5a",
-          "version": "1.2.0"
+          "revision": "c5fe7cc861a83ec75978a516c02398c2a2cb1f20",
+          "version": "1.2.1"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/rudderlabs/rudder-sdk-ios",
         "state": {
           "branch": null,
-          "revision": "383a515d144c36a5e173147b26be721a5c9d39f3",
-          "version": "1.23.1"
+          "revision": "6defba00e35d5652f83fbebd0b360d722bfaab34",
+          "version": "1.25.2"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(name: "AppsFlyerLib", url: "https://github.com/AppsFlyerSDK/AppsFlyerFramework", "6.12.2"..<"6.12.3"),
+        .package(name: "AppsFlyerLib", url: "https://github.com/AppsFlyerSDK/AppsFlyerFramework", "6.12.2"..<"7.0.0"),
         .package(name: "Rudder",url: "https://github.com/rudderlabs/rudder-sdk-ios", from: "1.0.0"),
     ],
     targets: [

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can also add the RudderStack iOS SDK via Swift Package Mangaer, via one of t
 
 * Enter the package repository (`git@github.com/rudderlabs/rudder-integration-appsflyer-ios.git`) in the search bar.
 
-* In **Dependency Rule**, select **Up to Next Major Version** and enter `2.4.0` as the value, as shown:
+* In **Dependency Rule**, select **Up to Next Major Version** and enter `2.5.0` as the value, as shown:
 
 ![Setting dependency](https://user-images.githubusercontent.com/59817155/145574696-8c849749-13e0-40d5-aacb-3fccb5c8e67d.png)
 
@@ -56,7 +56,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "git@github.com/rudderlabs/rudder-integration-appsflyer-ios.git", from: "2.4.0")
+        .package(url: "git@github.com/rudderlabs/rudder-integration-appsflyer-ios.git", from: "2.5.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "2.4.0",
+    "version": "2.5.0",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }


### PR DESCRIPTION
:crown: *An automated PR*

   2.4.0 (2024-03-06)<br> * chore: update codeowners files ([cb864b2](https://github.com/rudderlabs/rudder-integration-appsflyer-ios/commit/cb864b2))<br> * feat: set maximum version of AppsFlyer SDK to less than 7.0.0 in Package.swift ([0e70161](https://github.com/rudderlabs/rudder-integration-appsflyer-ios/commit/0e70161))<br> * Merge pull request  27 from rudderlabs/license/update/elv2 ([0e84634](https://github.com/rudderlabs/rudder-integration-appsflyer-ios/commit/0e84634)), closes [ 27](https://github.com/rudderlabs/rudder-integration-appsflyer-ios/issues/27)