### PR TITLE
chore(release): pulling release/2.6.0 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 2.6.0 (2024-04-03)
+
+
+### Features
+
+* change appsflyer package repository url ([186be7a](https://github.com/rudderlabs/rudder-integration-appsflyer-ios/commit/186be7abdccc0c8d90add9b518db833192368b6a))
+
 ## 2.5.0 (2024-03-06)
 
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "AppsFlyerLib",
-        "repositoryURL": "https://github.com/AppsFlyerSDK/AppsFlyerFramework",
+        "repositoryURL": "https://github.com/AppsFlyerSDK/AppsFlyerFramework-Static",
         "state": {
           "branch": null,
-          "revision": "4591cd113ea1af6fa950479fadbce2f13bab8895",
-          "version": "6.13.1"
+          "revision": "372811ca91c66fa9b235d845d647cdf8edf91304",
+          "version": "6.13.2"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/rudderlabs/rudder-sdk-ios",
         "state": {
           "branch": null,
-          "revision": "6defba00e35d5652f83fbebd0b360d722bfaab34",
-          "version": "1.25.2"
+          "revision": "e7f6d2ed7138598df96c23cec551d42359e80190",
+          "version": "1.26.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -14,14 +14,14 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(name: "AppsFlyerLib", url: "https://github.com/AppsFlyerSDK/AppsFlyerFramework", "6.12.2"..<"7.0.0"),
+        .package(name: "AppsFlyerLib-Static", url: "https://github.com/AppsFlyerSDK/AppsFlyerFramework-Static", "6.12.2"..<"7.0.0"),
         .package(name: "Rudder",url: "https://github.com/rudderlabs/rudder-sdk-ios", from: "1.0.0"),
     ],
     targets: [
         .target(
             name: "Rudder-Appsflyer",
             dependencies: [
-                .product(name: "AppsFlyerLib", package: "AppsFlyerLib"),
+                .product(name: "AppsFlyerLib-Static", package: "AppsFlyerLib-Static"),
                 .product(name: "Rudder", package: "Rudder"),
             ],
             path: "Rudder-Appsflyer",

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can also add the RudderStack iOS SDK via Swift Package Mangaer, via one of t
 
 * Enter the package repository (`git@github.com/rudderlabs/rudder-integration-appsflyer-ios.git`) in the search bar.
 
-* In **Dependency Rule**, select **Up to Next Major Version** and enter `2.5.0` as the value, as shown:
+* In **Dependency Rule**, select **Up to Next Major Version** and enter `2.6.0` as the value, as shown:
 
 ![Setting dependency](https://user-images.githubusercontent.com/59817155/145574696-8c849749-13e0-40d5-aacb-3fccb5c8e67d.png)
 
@@ -56,7 +56,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "git@github.com/rudderlabs/rudder-integration-appsflyer-ios.git", from: "2.5.0")
+        .package(url: "git@github.com/rudderlabs/rudder-integration-appsflyer-ios.git", from: "2.6.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "2.5.0",
+    "version": "2.6.0",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }


### PR DESCRIPTION
:crown: *An automated PR*

   2.5.0 (2024-04-03)<br> * feat: change appsflyer package repository url ([186be7a](https://github.com/rudderlabs/rudder-integration-appsflyer-ios/commit/186be7a))<br> * Merge pull request  31 from rudderlabs/release/2.5.0 ([e5fe07b](https://github.com/rudderlabs/rudder-integration-appsflyer-ios/commit/e5fe07b)), closes [ 31](https://github.com/rudderlabs/rudder-integration-appsflyer-ios/issues/31)

## Description

- Changed the AppsFlyer SPM link to a statically linked library URL. Please have a look here for more details: https://github.com/AppsFlyerSDK/AppsFlyerFramework/issues/263#issuecomment-2032421090.
- This change will address this issue:
```
Error
Invalid Bundle. The bundle MyApp.app/Frameworks/AppsFlyerLib.framework does not support the minimum OS Version specified in the Info.plist.
```