### PR TITLE
chore(release): pulling release/2.8.0 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 2.8.0 (2025-10-06)
+
+
+### Features
+
+* update appsflyer sdk to the latest version ([#54](https://github.com/rudderlabs/rudder-integration-appsflyer-ios/issues/54)) ([2ef69f6](https://github.com/rudderlabs/rudder-integration-appsflyer-ios/commit/2ef69f6f8ce952f070f4de94773642d4a27bc3ac))
+
 ## 2.7.0 (2024-07-09)
 
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,15 +1,15 @@
 PODS:
-  - AppsFlyerFramework (6.14.5):
-    - AppsFlyerFramework/Main (= 6.14.5)
-  - AppsFlyerFramework/Main (6.14.5)
-  - MetricsReporter (1.2.1):
+  - AppsFlyerFramework (6.17.6):
+    - AppsFlyerFramework/Main (= 6.17.6)
+  - AppsFlyerFramework/Main (6.17.6)
+  - MetricsReporter (2.0.0):
     - RSCrashReporter (= 1.0.1)
     - RudderKit (= 1.4.0)
   - RSCrashReporter (1.0.1)
-  - Rudder (1.27.0):
-    - MetricsReporter (= 1.2.1)
-  - Rudder-Appsflyer (2.6.0):
-    - AppsFlyerFramework (~> 6.14.5)
+  - Rudder (1.31.1):
+    - MetricsReporter (= 2.0.0)
+  - Rudder-Appsflyer (2.7.0):
+    - AppsFlyerFramework (~> 6.14)
     - Rudder (~> 1.12)
   - RudderKit (1.4.0)
 
@@ -29,13 +29,13 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  AppsFlyerFramework: 6bd90198428b9646a5653f8e0f19de529788b70e
-  MetricsReporter: 99596ee5003c69949ed2f50acc34aee83c42f843
+  AppsFlyerFramework: c2a11846e1f716132449810e0fb5f191f4f1bf4c
+  MetricsReporter: 364b98791e868b10e9d512eb50af28d8c11e5cdb
   RSCrashReporter: 6b8376ac729b0289ebe0908553e5f56d8171f313
-  Rudder: 3cfcd9e6c5359cd6d49f411101ed9b894e3b64bd
-  Rudder-Appsflyer: 37b22337c863d400889b2df15395893905e35e9b
+  Rudder: 352cb3417238fb84cc083826d9a5a7cc91efaa69
+  Rudder-Appsflyer: 66b95ecacbacc18f71d8a6176a02b32321d66092
   RudderKit: f272f9872183946452ac94cd7bb2244a71e6ca8f
 
 PODFILE CHECKSUM: 7f2df08a24e0126cb04b415091e6cb134ba7c89b
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/AppsFlyerSDK/AppsFlyerFramework-Static",
         "state": {
           "branch": null,
-          "revision": "9388e8ccb6174a1be2f04afe3652d4ce0f561fa1",
-          "version": "6.14.5"
+          "revision": "1741d025d5bdd8a64c42854ba0fcfd7f768e4594",
+          "version": "6.17.5"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(name: "AppsFlyerLib-Static", url: "https://github.com/AppsFlyerSDK/AppsFlyerFramework-Static", "6.14.5"..<"6.14.6"),
+        .package(name: "AppsFlyerLib-Static", url: "https://github.com/AppsFlyerSDK/AppsFlyerFramework-Static", from: "6.17"),
         .package(name: "Rudder",url: "https://github.com/rudderlabs/rudder-sdk-ios", from: "1.0.0"),
     ],
     targets: [

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can also add the RudderStack iOS SDK via Swift Package Mangaer, via one of t
 
 * Enter the package repository (`git@github.com/rudderlabs/rudder-integration-appsflyer-ios.git`) in the search bar.
 
-* In **Dependency Rule**, select **Up to Next Major Version** and enter `2.7.0` as the value, as shown:
+* In **Dependency Rule**, select **Up to Next Major Version** and enter `2.8.0` as the value, as shown:
 
 ![Setting dependency](https://user-images.githubusercontent.com/59817155/145574696-8c849749-13e0-40d5-aacb-3fccb5c8e67d.png)
 
@@ -56,7 +56,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "git@github.com/rudderlabs/rudder-integration-appsflyer-ios.git", from: "2.7.0")
+        .package(url: "git@github.com/rudderlabs/rudder-integration-appsflyer-ios.git", from: "2.8.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Rudder-Appsflyer.podspec
+++ b/Rudder-Appsflyer.podspec
@@ -2,7 +2,7 @@ require 'json'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
-appsflyer_sdk_version = '~> 6.14.5'
+appsflyer_sdk_version = '~> 6.14'
 rudder_sdk_version = '~> 1.12'
 
 Pod::Spec.new do |s|

--- a/Rudder-Appsflyer/Classes/RudderAppsflyerIntegration.m
+++ b/Rudder-Appsflyer/Classes/RudderAppsflyerIntegration.m
@@ -108,7 +108,8 @@ NSArray<NSString*>* TRACK_RESERVED_KEYWORDS;
             else if ([eventName isEqualToString:ECommPromotionViewed]){
                 afEventName = AFEventAdView;
                 if(properties[CREATIVE]) {
-                    [afProperties setValue:properties[CREATIVE] forKey:AFEventParamAdRevenueAdType];
+                    [afProperties setValue:properties[CREATIVE] forKey:@"af_adrev_ad_type"];
+                    [afProperties setValue:properties[CREATIVE] forKey:kAppsFlyerAdRevenueAdType];
                 }
                 if(properties[KeyCurrency]) {
                     [afProperties setValue:properties[KeyCurrency] forKey:AFEventParamCurrency];
@@ -117,7 +118,8 @@ NSArray<NSString*>* TRACK_RESERVED_KEYWORDS;
             else if ([eventName isEqualToString:ECommPromotionClicked]){
                 afEventName = AFEventAdClick;
                 if(properties[CREATIVE]) {
-                    [afProperties setValue:properties[CREATIVE] forKey:AFEventParamAdRevenueAdType];
+                    [afProperties setValue:properties[CREATIVE] forKey:@"af_adrev_ad_type"];
+                    [afProperties setValue:properties[CREATIVE] forKey:kAppsFlyerAdRevenueAdType];
                 }
                 if(properties[KeyCurrency]) {
                     [afProperties setValue:properties[KeyCurrency] forKey:AFEventParamCurrency];

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "2.7.0",
+    "version": "2.8.0",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }


### PR DESCRIPTION
:crown: *An automated PR*

   2.7.0 (2025-10-06)<br> * feat: update appsflyer sdk to the latest version ( 54) ([2ef69f6](https://github.com/rudderlabs/rudder-integration-appsflyer-ios/commit/2ef69f6)), closes [ 54](https://github.com/rudderlabs/rudder-integration-appsflyer-ios/issues/54)<br> * Merge pull request  52 from rudderlabs/ci/sdk-4006-ios-use-commit-shas-for-external-actions ([732344e](https://github.com/rudderlabs/rudder-integration-appsflyer-ios/commit/732344e)), closes [ 52](https://github.com/rudderlabs/rudder-integration-appsflyer-ios/issues/52)