### PR TITLE
chore(release): pulling release/2.9.0 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 2.9.0 (2025-10-22)
+
+
+### Features
+
+* **appsflyer:** update identify event to use setUserEmails API ([277ebfc](https://github.com/rudderlabs/rudder-integration-appsflyer-ios/commit/277ebfc81423420ffb3e394e6633b325f28c384a))
+
 ## 2.8.0 (2025-10-06)
 
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can also add the RudderStack iOS SDK via Swift Package Mangaer, via one of t
 
 * Enter the package repository (`git@github.com/rudderlabs/rudder-integration-appsflyer-ios.git`) in the search bar.
 
-* In **Dependency Rule**, select **Up to Next Major Version** and enter `2.8.0` as the value, as shown:
+* In **Dependency Rule**, select **Up to Next Major Version** and enter `2.9.0` as the value, as shown:
 
 ![Setting dependency](https://user-images.githubusercontent.com/59817155/145574696-8c849749-13e0-40d5-aacb-3fccb5c8e67d.png)
 
@@ -56,7 +56,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "git@github.com/rudderlabs/rudder-integration-appsflyer-ios.git", from: "2.8.0")
+        .package(url: "git@github.com/rudderlabs/rudder-integration-appsflyer-ios.git", from: "2.9.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Rudder-Appsflyer/Classes/RudderAppsflyerIntegration.m
+++ b/Rudder-Appsflyer/Classes/RudderAppsflyerIntegration.m
@@ -55,19 +55,8 @@ NSArray<NSString*>* TRACK_RESERVED_KEYWORDS;
         
         NSMutableDictionary *afTraits = [[NSMutableDictionary alloc] init];
         if ([message.context.traits[@"email"] isKindOfClass:[NSString class]]) {
-            [afTraits setObject:message.context.traits[@"email"] forKey:@"email"];
-        }
-        
-        if ([message.context.traits[@"firstName"] isKindOfClass:[NSString class]]) {
-            [afTraits setObject:message.context.traits[@"firstName"] forKey:@"firstName"];
-        }
-        
-        if ([message.context.traits[@"lastName"] isKindOfClass:[NSString class]]) {
-            [afTraits setObject:message.context.traits[@"lastName"] forKey:@"lastName"];
-        }
-        
-        if ([message.context.traits[@"username"] isKindOfClass:[NSString class]]) {
-            [afTraits setObject:message.context.traits[@"username"] forKey:@"username"];
+            NSString *emailValue = (NSString *)message.context.traits[@"email"];
+            [[AppsFlyerLib shared] setUserEmails:@[emailValue] withCryptType:EmailCryptTypeNone];
         }
         
         [[AppsFlyerLib shared] setAdditionalData:afTraits];

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "2.8.0",
+    "version": "2.9.0",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }


### PR DESCRIPTION
:crown: *An automated PR*

   2.8.0 (2025-10-22)<br> * feat(appsflyer): update identify event to use setUserEmails API ([277ebfc](https://github.com/rudderlabs/rudder-integration-appsflyer-ios/commit/277ebfc))<br> * Merge pull request  55 from rudderlabs/release/2.8.0 ([1185562](https://github.com/rudderlabs/rudder-integration-appsflyer-ios/commit/1185562)), closes [ 55](https://github.com/rudderlabs/rudder-integration-appsflyer-ios/issues/55)