### PR TITLE
chore(release): pulling release/3.0.0 into master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## 3.0.0 (2025-10-22)
+
+
+### ⚠ BREAKING CHANGES
+
+* **appsflyer:** update identify event to use setUserEmails API
+
+### Features
+
+* **appsflyer:** update identify event to use setUserEmails API ([779f32a](https://github.com/rudderlabs/rudder-integration-appsflyer-ios/commit/779f32a391daaca3d91a6e0b1db87367c7202de4))
+
 ## 2.8.0 (2025-10-06)
 
 

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - RSCrashReporter (1.0.1)
   - Rudder (1.31.1):
     - MetricsReporter (= 2.0.0)
-  - Rudder-Appsflyer (2.7.0):
+  - Rudder-Appsflyer (2.8.0):
     - AppsFlyerFramework (~> 6.14)
     - Rudder (~> 1.12)
   - RudderKit (1.4.0)
@@ -33,7 +33,7 @@ SPEC CHECKSUMS:
   MetricsReporter: 364b98791e868b10e9d512eb50af28d8c11e5cdb
   RSCrashReporter: 6b8376ac729b0289ebe0908553e5f56d8171f313
   Rudder: 352cb3417238fb84cc083826d9a5a7cc91efaa69
-  Rudder-Appsflyer: 66b95ecacbacc18f71d8a6176a02b32321d66092
+  Rudder-Appsflyer: 89f8a8a86094e79f915d66adb3ba8252faa01a2c
   RudderKit: f272f9872183946452ac94cd7bb2244a71e6ca8f
 
 PODFILE CHECKSUM: 7f2df08a24e0126cb04b415091e6cb134ba7c89b

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You can also add the RudderStack iOS SDK via Swift Package Mangaer, via one of t
 
 * Enter the package repository (`git@github.com/rudderlabs/rudder-integration-appsflyer-ios.git`) in the search bar.
 
-* In **Dependency Rule**, select **Up to Next Major Version** and enter `2.8.0` as the value, as shown:
+* In **Dependency Rule**, select **Up to Next Major Version** and enter `3.0.0` as the value, as shown:
 
 ![Setting dependency](https://user-images.githubusercontent.com/59817155/145574696-8c849749-13e0-40d5-aacb-3fccb5c8e67d.png)
 
@@ -56,7 +56,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "git@github.com/rudderlabs/rudder-integration-appsflyer-ios.git", from: "2.8.0")
+        .package(url: "git@github.com/rudderlabs/rudder-integration-appsflyer-ios.git", from: "3.0.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Rudder-Appsflyer/Classes/RudderAppsflyerIntegration.m
+++ b/Rudder-Appsflyer/Classes/RudderAppsflyerIntegration.m
@@ -49,28 +49,10 @@ NSArray<NSString*>* TRACK_RESERVED_KEYWORDS;
     if ([type isEqualToString:@"identify"]) {
         [[AppsFlyerLib shared] setCustomerUserID:message.userId];
         
-        if ([message.context.traits[@"currencyCode"] isKindOfClass:[NSString class]]) {
-            [AppsFlyerLib shared].currencyCode = [[NSString alloc] initWithFormat:@"%@", message.context.traits[@"currencyCode"]];
-        }
-        
-        NSMutableDictionary *afTraits = [[NSMutableDictionary alloc] init];
         if ([message.context.traits[@"email"] isKindOfClass:[NSString class]]) {
-            [afTraits setObject:message.context.traits[@"email"] forKey:@"email"];
+            NSString *emailValue = (NSString *)message.context.traits[@"email"];
+            [[AppsFlyerLib shared] setUserEmails:@[emailValue] withCryptType:EmailCryptTypeSHA256];
         }
-        
-        if ([message.context.traits[@"firstName"] isKindOfClass:[NSString class]]) {
-            [afTraits setObject:message.context.traits[@"firstName"] forKey:@"firstName"];
-        }
-        
-        if ([message.context.traits[@"lastName"] isKindOfClass:[NSString class]]) {
-            [afTraits setObject:message.context.traits[@"lastName"] forKey:@"lastName"];
-        }
-        
-        if ([message.context.traits[@"username"] isKindOfClass:[NSString class]]) {
-            [afTraits setObject:message.context.traits[@"username"] forKey:@"username"];
-        }
-        
-        [[AppsFlyerLib shared] setAdditionalData:afTraits];
     } else if ([type isEqualToString:@"track"]) {
         NSString *eventName = message.event;
         if (eventName != nil) {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
-    "version": "2.8.0",
+    "version": "3.0.0",
     "description": "Rudder is a platform for collecting, storing and routing customer event data to dozens of tools"
 }


### PR DESCRIPTION
# :crown: *An automated PR*

   2.8.0 (2025-10-22)<br> * feat(appsflyer)!: update identify event to use setUserEmails API ([779f32a](https://github.com/rudderlabs/rudder-integration-appsflyer-ios/commit/779f32a))<br> * Merge pull request  55 from rudderlabs/release/2.8.0 ([1185562](https://github.com/rudderlabs/rudder-integration-appsflyer-ios/commit/1185562)), closes [ 55](https://github.com/rudderlabs/rudder-integration-appsflyer-ios/issues/55)


## Description

This PR updates the identify event implementation in the Rudder-Appsflyer iOS integration to use AppsFlyer's native `setUserEmails` API instead of the generic `setAdditionalData` method. The change improves data handling for user email addresses by leveraging AppsFlyer's dedicated email API with SHA256 encryption support.

**Breaking Change**: This update removes the ability to pass firstName, lastName, username, and currencyCode traits through the identify event. Only email addresses are now supported for identify events using the new API.

## Key Changes

- **Removed**: Custom traits dictionary approach using `setAdditionalData` for identify events
- **Removed**: Support for firstName, lastName, username, and currencyCode traits in identify events
- **Added**: Direct `setUserEmails` API usage with SHA256 encryption for email trait handling
- **Updated**: Podfile.lock reflecting version bump to 2.8.0

## Breaking Changes

This is a **breaking change**
- Identify events no longer support `firstName`, `lastName`, `username`, and `currencyCode` traits
- Only `email` trait is processed in identify events using the new `setUserEmails` API
- Applications relying on these traits will need to be updated