### PR TITLE
feat: remove duplicate ad-revenue key

### DIFF
--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -62,4 +62,4 @@ jobs:
         with:
           branches: 'release/*'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/Rudder-Appsflyer/Classes/RudderAppsflyerIntegration.m
+++ b/Rudder-Appsflyer/Classes/RudderAppsflyerIntegration.m
@@ -91,7 +91,6 @@ NSArray<NSString*>* TRACK_RESERVED_KEYWORDS;
                 afEventName = AFEventAdView;
                 if(properties[CREATIVE]) {
                     [afProperties setValue:properties[CREATIVE] forKey:@"af_adrev_ad_type"];
-                    [afProperties setValue:properties[CREATIVE] forKey:kAppsFlyerAdRevenueAdType];
                 }
                 if(properties[KeyCurrency]) {
                     [afProperties setValue:properties[KeyCurrency] forKey:AFEventParamCurrency];
@@ -101,7 +100,6 @@ NSArray<NSString*>* TRACK_RESERVED_KEYWORDS;
                 afEventName = AFEventAdClick;
                 if(properties[CREATIVE]) {
                     [afProperties setValue:properties[CREATIVE] forKey:@"af_adrev_ad_type"];
-                    [afProperties setValue:properties[CREATIVE] forKey:kAppsFlyerAdRevenueAdType];
                 }
                 if(properties[KeyCurrency]) {
                     [afProperties setValue:properties[KeyCurrency] forKey:AFEventParamCurrency];


### PR DESCRIPTION
## Description
Remove duplicate `kAppsFlyerAdRevenueAdType` key mapping in promotion events (`Promotion Viewed` and `Promotion Clicked`) and fix a silent CI failure where the release branch deletion step lacked write permissions.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactor/optimization

## Implementation Details
- **Remove duplicate ad-revenue key:** In `RudderAppsflyerIntegration.m`, the `Promotion Viewed` and `Promotion Clicked` event handlers were setting the same `CREATIVE` property value to both `@"af_adrev_ad_type"` (literal string) and `kAppsFlyerAdRevenueAdType` (SDK constant that resolves to `af_adrev_ad_type`). Removed the redundant `kAppsFlyerAdRevenueAdType` line in both handlers.
- **Fix release branch deletion token:** In `publish-new-release.yml`, the "Delete release branch" step used `secrets.GITHUB_TOKEN` which is restricted to read-only by the job-level `permissions: contents: read` added during the SEC-58 migration. Replaced with the app token (`steps.generate-token.outputs.token`) that already has `contents: write` permission.

## Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation (if appropriate).
- [x] I have ensured that my code follows the project's code style.
- [x] I have checked for potential performance impacts and optimized if necessary.
- [x] I have checked the code for security issues.
- [ ] I have updated the changelog (if required).

## How to test?
- **Duplicate key fix:** Trigger a `Promotion Viewed` or `Promotion Clicked` event and verify that `af_adrev_ad_type` is set once (not duplicated) in the AppsFlyer event properties.
- **CI fix:** Merge a release PR and verify the "Delete release branch" step successfully deletes the branch (check workflow logs for absence of 403 error in the `deleteRef` call).

## Breaking Changes
None

## Maintainers Checklist
- [ ] The code has been reviewed.
- [ ] CI tests have passed.
- [ ] All necessary documentation has been updated.

## Screenshots (if applicable)
N/A

## Additional Context
The CI fix addresses a silent failure introduced by the SEC-58 PAT-to-App-Token migration. The `koj-co/delete-merged-action` swallows API errors, so the step appeared to succeed even when the `deleteRef` call returned a 403. Repos with the `delete_branch_on_merge` GitHub setting enabled may not notice the issue since GitHub auto-deletes the branch on merge.